### PR TITLE
Use std::distance to get number of terms

### DIFF
--- a/include/spdmon/spdmon.hpp
+++ b/include/spdmon/spdmon.hpp
@@ -750,7 +750,7 @@ namespace spdmon
             begin_(std::begin(iter)),
             end_(std::end(iter))
         {
-            progress_logger_ = std::make_shared<LoggerProgress>("Progress logger", end_ - begin_);
+            progress_logger_ = std::make_shared<LoggerProgress>("Progress logger", std::distance(begin_, end_));
         }
 
         const IterableProgressMonitor& begin() const { return *this; }


### PR DESCRIPTION
The operator- is not defined for const iterator. To get the size, switch to using std::distance.